### PR TITLE
Fix issue:TypeError: Cannot read properties of null (reading 'querySelector')

### DIFF
--- a/lib/pdfviewer/pdfviewer_web.dart
+++ b/lib/pdfviewer/pdfviewer_web.dart
@@ -35,7 +35,7 @@ class _WebViewerState extends State<WebViewer> {
       ..id = 'canvas'
       ..append(html.ScriptElement()
         ..text = """
-        const canvas = document.querySelector("flt-platform-view").shadowRoot.querySelector("#canvas");
+        const canvas = document.querySelector("flt-platform-view").querySelector("#canvas");
         WebViewer({
           path: 'WebViewer/lib',
           initialDoc: '${widget._document}'


### PR DESCRIPTION
 Contents defined in "flt-platform-view" elements are now projected outside the shadow root